### PR TITLE
ci: build and push Docker images on release

### DIFF
--- a/.github/workflows/images_alpy.yml
+++ b/.github/workflows/images_alpy.yml
@@ -1,0 +1,128 @@
+name: Publish Docker Images (Alpy)
+
+on:
+  workflow_call:
+    inputs:
+      IMAGE_REGISTRY:
+        required: true
+        type: string
+        default: "ccpgames"
+      PSYCOPG_VERSION:
+        required: true
+        type: string
+      GRPCIO_IMAGE_VERSION:
+        required: true
+        type: string
+      PROTOPLASM_PY_PKG_VERSION:
+        required: true
+        type: string
+    secrets:
+      REGISTRY_USER:
+        required: true
+      REGISTRY_TOKEN:
+        required: true
+
+jobs:
+  alpy_base:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ "3.8.18", "3.9.18", "3.10.13", "3.11.8", "3.12.2" ]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_TOKEN }}
+
+      - name: Set config variable env
+        run: |
+          ALPY_VERSION=`echo ${{ matrix.python-version }} | cut -d. -f1,2`
+          echo "ALPY_VERSION=$ALPY_VERSION" >> $GITHUB_ENV
+          echo "HASH_VERSION=${{ hashFiles('requirements.txt', 'docker/alpy/base.Dockerfile') }}" >> $GITHUB_ENV
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/alpy/base.Dockerfile
+          network: host
+          no-cache: true
+          push: true
+          build-args: |
+            PYTHON_VERSION=${{ matrix.python-version }}
+          tags: |
+            ${{ inputs.IMAGE_REGISTRY }}/grpcio-alpy${{ env.ALPY_VERSION }}-base:${{ inputs.GRPCIO_IMAGE_VERSION }}-${{ env.HASH_VERSION }}
+            ${{ inputs.IMAGE_REGISTRY }}/grpcio-alpy${{ env.ALPY_VERSION }}-base:latest
+
+  alpy:
+    runs-on: ubuntu-latest
+    needs: [ alpy_base ]
+    strategy:
+      matrix:
+        alpy-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_TOKEN }}
+
+      - name: Set config variable env
+        run: |
+          echo "IMG_FULL=${{ inputs.IMAGE_REGISTRY }}/protoplasm:${{ inputs.PROTOPLASM_PY_PKG_VERSION }}-alpy${{ matrix.alpy-version }}" >> $GITHUB_ENV
+          echo "HASH_VERSION=${{ hashFiles('requirements.txt', 'docker/alpy/base.Dockerfile') }}" >> $GITHUB_ENV
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/alpy/Dockerfile
+          network: host
+          no-cache: true
+          push: true
+          build-args: |
+            PACKAGE_VERSION=${{ inputs.PROTOPLASM_PY_PKG_VERSION }}
+            BASE_IMAGE=${{ inputs.IMAGE_REGISTRY }}/grpcio-alpy${{ matrix.alpy-version }}-base:${{ inputs.GRPCIO_IMAGE_VERSION }}-${{ env.HASH_VERSION }}
+          tags: |
+            ${{ env.IMG_FULL }}
+            ${{ inputs.IMAGE_REGISTRY }}/protoplasm:latest-alpy${{ env.ALPY_VERSION }}
+
+  alpy_psycopg:
+    runs-on: ubuntu-latest
+    needs: [ alpy ]
+    strategy:
+      matrix:
+        alpy-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_TOKEN }}
+
+      - name: Set config variable env
+        run: |
+          echo "IMG_FULL=${{ inputs.IMAGE_REGISTRY }}/protoplasm:${{ inputs.PROTOPLASM_PY_PKG_VERSION }}-alpy${{ matrix.alpy-version }}-psycopg${{ inputs.PSYCOPG_VERSION }}" >> $GITHUB_ENV
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/alpy/psycopg.Dockerfile
+          network: host
+          no-cache: true
+          push: true
+          build-args: |
+            BASE_IMAGE=${{ inputs.IMAGE_REGISTRY }}/protoplasm:${{ inputs.PROTOPLASM_PY_PKG_VERSION }}-alpy${{ matrix.alpy-version }}
+            PSYCOPG_VERSION=${{ inputs.PSYCOPG_VERSION }}
+          tags: |
+            ${{ env.IMG_FULL }}
+            ${{ inputs.IMAGE_REGISTRY }}/protoplasm:latest-alpy${{ matrix.alpy-version }}-psycopg${{ inputs.PROTOPLASM_PY_PKG_VERSION }}
+            ${{ inputs.IMAGE_REGISTRY }}/protoplasm:latest-alpy${{ matrix.alpy-version }}-psycopg

--- a/.github/workflows/images_depy.yml
+++ b/.github/workflows/images_depy.yml
@@ -1,0 +1,91 @@
+name: Publish Docker Images (Depy)
+
+on:
+  workflow_call:
+    inputs:
+      IMAGE_REGISTRY:
+        required: true
+        type: string
+        default: "ccpgames"
+      PYODBC_VERSION:
+        required: true
+        type: string
+      PROTOPLASM_PY_PKG_VERSION:
+        required: true
+        type: string
+    secrets:
+      REGISTRY_USER:
+        required: true
+      REGISTRY_TOKEN:
+        required: true
+
+jobs:
+  depy:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ "3.8.18", "3.9.18", "3.10.13", "3.11.8", "3.12.2"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_TOKEN }}
+
+      - name: Set config variable env
+        run: |
+          DEPY_VERSION=`echo ${{ matrix.python-version }} | cut -d. -f1,2`
+          echo "DEPY_VERSION=${DEPY_VERSION}" >> $GITHUB_ENV
+          echo "IMG_FULL=${{ inputs.IMAGE_REGISTRY }}/protoplasm:${{ inputs.PROTOPLASM_PY_PKG_VERSION }}-depy${DEPY_VERSION}" >> $GITHUB_ENV
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/depy/Dockerfile
+          network: host
+          no-cache: true
+          push: true
+          build-args: |
+            PYTHON_VERSION=${{ matrix.python-version }}
+            PACKAGE_VERSION=${{ inputs.PROTOPLASM_PY_PKG_VERSION }}
+          tags: |
+            ${{ env.IMG_FULL }}
+            ${{ inputs.IMAGE_REGISTRY }}/protoplasm:latest-depy${{ env.DEPY_VERSION }}
+
+  depy_pyodbc:
+    runs-on: ubuntu-latest
+    needs: [ depy ]
+    strategy:
+      matrix:
+        depy-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_TOKEN }}
+
+      - name: Set config variable env
+        run: |
+          echo "IMG_FULL=${{ inputs.IMAGE_REGISTRY }}/protoplasm:${{ inputs.PROTOPLASM_PY_PKG_VERSION }}-depy${{ matrix.depy-version }}-pyodbc${{ inputs.PYODBC_VERSION }}" >> $GITHUB_ENV
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/depy/pyodbc.Dockerfile
+          network: host
+          no-cache: true
+          push: true
+          build-args: |
+            BASE_IMAGE=${{ inputs.IMAGE_REGISTRY }}/protoplasm:${{ inputs.PROTOPLASM_PY_PKG_VERSION }}-depy${{ matrix.depy-version }}
+            PYODBC_VERSION=${{ inputs.PYODBC_VERSION }}
+          tags: |
+            ${{ env.IMG_FULL }}
+            ${{ inputs.IMAGE_REGISTRY }}/protoplasm:latest-depy${{ matrix.depy-version }}-pyodbc${{ inputs.PYODBC_VERSION }}
+            ${{ inputs.IMAGE_REGISTRY }}/protoplasm:latest-depy${{ matrix.depy-version }}-pyodbc

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,12 @@
+name: Pre Release
+
+on:
+  release:
+    types: [ prereleased ]
+
+jobs:
+  release_to_pypi:
+    name: Publish protoplasm to pypi
+    uses: ./.github/workflows/publish-to-pypi.yml
+    secrets:
+      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,26 +1,32 @@
 name: Publish Python Package
 
 on:
-  release:
-    types: [ created ]
+  workflow_call:
+    secrets:
+      PYPI_API_TOKEN:
+        required: true
 
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: '3.8'
+
       - name: Install Dependencies
         run: |
           python --version
           python -m pip install --upgrade pip
           pip install --upgrade setuptools wheel twine
+
       - name: Build and Package
         run: |
           python setup.py sdist bdist_wheel
+
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@v1.4.2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Release
+
+on:
+  release:
+    types: [ released ]
+
+jobs:
+  release_to_pypi:
+    name: Publish protoplasm to pypi
+    uses: ./.github/workflows/publish-to-pypi.yml
+    secrets:
+      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+
+  retrieve_version:
+    runs-on: ubuntu-latest
+    name: Retrieve protoplasm python package version
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: |
+          PROTOPLASM_PY_PKG_FULL_VERSION=`python3 -c "import protoplasm; print(protoplasm.__version__)"`
+          PROTOPLASM_PY_PKG_SHORT_VERSION=`echo ${PROTOPLASM_PY_PKG_FULL_VERSION} | cut -d. -f1,2`
+          echo "PROTOPLASM_PY_PKG_VERSION=${PROTOPLASM_PY_PKG_SHORT_VERSION}" >> $GITHUB_ENV
+          echo "protoplasm version is ${PROTOPLASM_PY_PKG_FULL_VERSION}"
+    outputs:
+      version: ${{ env.PROTOPLASM_PY_PKG_VERSION }}
+
+  image_alpy:
+    name: Build and push alpy images
+    needs: [ release_to_pypi, retrieve_version ]
+    uses: ./.github/workflows/images_alpy.yml
+    with:
+      PROTOPLASM_PY_PKG_VERSION: ${{ needs.retrieve_version.outputs.version }}
+      GRPCIO_IMAGE_VERSION: "1.62.1"
+      PSYCOPG_VERSION: "3.1"
+    secrets:
+      REGISTRY_USER: ${{ secrets.REGISTRY_USER }}
+      REGISTRY_TOKEN: ${{ secrets.REGISTRY_TOKEN }}
+
+  image_depy:
+    name: Build and push depy images
+    needs: [ release_to_pypi, retrieve_version ]
+    uses: ./.github/workflows/images_depy.yml
+    with:
+      PROTOPLASM_PY_PKG_VERSION: ${{ needs.retrieve_version.outputs.version }}
+      PYODBC_VERSION: "5.1"
+    secrets:
+      REGISTRY_USER: ${{ secrets.REGISTRY_USER }}
+      REGISTRY_TOKEN: ${{ secrets.REGISTRY_TOKEN }}

--- a/docker/alpy/Dockerfile
+++ b/docker/alpy/Dockerfile
@@ -1,0 +1,21 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+ARG PACKAGE_VERSION
+ENV PACKAGE_VERSION=${PACKAGE_VERSION}
+
+RUN echo Package Version is $PACKAGE_VERSION \
+ && echo Package Version in loops is ${PACKAGE_VERSION} \
+ && echo "Package Version in loops and string is ${PACKAGE_VERSION}" \
+ && apk add --update --no-cache --virtual .build-deps \
+    gcc \
+    linux-headers \
+    make \
+    musl-dev \
+    python3-dev \
+    libffi-dev \
+    g++ \
+ && python -m pip install --upgrade pip \
+ && python -m pip install --upgrade cryptography \
+ && python -m pip install --upgrade "protoplasm==${PACKAGE_VERSION}.*" \
+ && apk del .build-deps

--- a/docker/alpy/base.Dockerfile
+++ b/docker/alpy/base.Dockerfile
@@ -1,0 +1,19 @@
+ARG PYTHON_VERSION
+FROM python:${PYTHON_VERSION}-alpine3.19
+
+COPY requirements.txt .
+
+RUN apk add --update --no-cache --virtual .build-deps \
+    gcc \
+    linux-headers \
+    make \
+    musl-dev \
+    python3-dev \
+    libffi-dev \
+    g++ \
+ && python -m pip install --upgrade pip \
+ && python -m pip install --upgrade cryptography \
+ && python -m pip install --upgrade -r requirements.txt \
+ && apk del .build-deps \
+ && rm -f requirements.txt \
+ && apk add --update --no-cache libstdc++

--- a/docker/alpy/psycopg.Dockerfile
+++ b/docker/alpy/psycopg.Dockerfile
@@ -1,0 +1,19 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+ARG PSYCOPG_VERSION
+ENV PSYCOPG_VERSION=${PSYCOPG_VERSION}
+
+RUN apk add --update --no-cache --virtual .build-deps \
+    gcc \
+    linux-headers \
+    make \
+    musl-dev \
+    python3-dev \
+    libffi-dev \
+    g++ \
+    postgresql-dev \
+ && python -m pip install --upgrade pip \
+ && python -m pip install --upgrade "psycopg[binary]==${PSYCOPG_VERSION}.*" \
+ && apk del .build-deps \
+ && apk add --update --no-cache libpq

--- a/docker/depy/Dockerfile
+++ b/docker/depy/Dockerfile
@@ -1,0 +1,14 @@
+ARG PYTHON_VERSION
+FROM python:${PYTHON_VERSION}-slim-bookworm
+
+ARG PACKAGE_VERSION
+ENV PACKAGE_VERSION=${PACKAGE_VERSION}
+
+# Stuff and libraries
+RUN apt-get update \
+ && apt-get install -y \
+    apt-transport-https \
+    python3-dev \
+    --no-install-recommends \
+ && python -m pip install --upgrade pip \
+ && python -m pip install --upgrade "protoplasm==${PACKAGE_VERSION}.*"

--- a/docker/depy/pyodbc.Dockerfile
+++ b/docker/depy/pyodbc.Dockerfile
@@ -1,0 +1,29 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+ARG PYODBC_VERSION
+ENV PYODBC_VERSION=${PYODBC_VERSION}
+
+RUN apt-get update \
+ && ACCEPT_EULA=Y apt-get install -y curl \
+                                     gnupg \
+ && apt-get clean \
+ && apt-get autoremove --purge
+
+# Get some keys that seems proper
+RUN curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg
+
+# Download appropriate package for the OS version - Debian 12
+RUN curl https://packages.microsoft.com/config/debian/12/prod.list > /etc/apt/sources.list.d/mssql-release.list
+
+# Install the drivers, tools, Dev libraries & necessary locales
+RUN apt-get update \
+ && ACCEPT_EULA=Y apt-get install -y msodbcsql17 \
+                                     unixodbc-dev \
+                                     python3-dev \
+                                     g++ \
+ && python -m pip install "pyodbc==${PYODBC_VERSION}.*" \
+ && apt-get purge -y --auto-remove unixodbc-dev \
+                                   g++ \
+ && apt-get -y clean \
+ && apt-get autoremove -y --purge \


### PR DESCRIPTION
Also refactor the "publish to pypi" workflow into a global "release" workflow.
because the images depend on the package being published.

Run sample: 

<a href="https://github.com/ccpgames/protoplasm/actions/runs/8732653645"><img width="1333" alt="Screenshot 2024-04-18 at 13 08 29" src="https://github.com/ccpgames/protoplasm/assets/2945291/2f008f29-ef4b-4b5a-9c6d-be010f7fe8d3"></a>
